### PR TITLE
[UPDATE] Back to using the original SCTP library.

### DIFF
--- a/ngapSctp/sctp.go
+++ b/ngapSctp/sctp.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"unsafe"
 
-	"git.cs.nctu.edu.tw/calee/sctp"
+	"github.com/ishidawataru/sctp"
 
 	"free5gc/lib/ngap/logger"
 )


### PR DESCRIPTION
Back to using the original SCTP library, until errors with the new one are resolved.