### PR TITLE
Added UE Aggregate Maximum Bit Rate

### DIFF
--- a/ngapType/ProtocolIEField.go
+++ b/ngapType/ProtocolIEField.go
@@ -395,6 +395,7 @@ const (
 	PDUSessionResourceSetupRequestIEsPresentRANPagingPriority
 	PDUSessionResourceSetupRequestIEsPresentNASPDU
 	PDUSessionResourceSetupRequestIEsPresentPDUSessionResourceSetupListSUReq
+	PDUSessionResourceSetupRequestIEsPresentUEAggregateMaximumBitRate
 )
 
 type PDUSessionResourceSetupRequestIEsValue struct {
@@ -404,6 +405,7 @@ type PDUSessionResourceSetupRequestIEsValue struct {
 	RANPagingPriority                *RANPagingPriority                `aper:"referenceFieldValue:83"`
 	NASPDU                           *NASPDU                           `aper:"referenceFieldValue:38"`
 	PDUSessionResourceSetupListSUReq *PDUSessionResourceSetupListSUReq `aper:"referenceFieldValue:74"`
+	UEAggregateMaximumBitRate        *UEAggregateMaximumBitRate        `aper:"valueExt,referenceFieldValue:110"`
 }
 
 type PDUSessionResourceSetupResponseIEs struct {


### PR DESCRIPTION
Required for working with 5G UE in SA mode as if there is an "internet" and "ims" DNN APN, in addition to the specific bandwidth an overall bandwidth must be set.

Tested with Huawei P40.